### PR TITLE
Add minimum version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ pip install pytest
 cd rpn-calc/src
 pytest
 ```
+
+The minimum required version of Python is 3.10.

--- a/rpn-calc/src/rpn_calc.py
+++ b/rpn-calc/src/rpn_calc.py
@@ -10,6 +10,9 @@ from calculator import Calculator
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+MIN_PYTHON = (3, 10)
+if sys.version_info < MIN_PYTHON:
+    sys.exit("Python %s.%s or later is required.\n" % MIN_PYTHON)
 
 def main(commands: "Iterable" = sys.stdin):
     '''


### PR DESCRIPTION
This commit enforces a minimum Python interpreter version. In #2 it seems that 3.10 is the minimum needed to support `match`