### PR TITLE
multiple spaces will no longer cause exception

### DIFF
--- a/rpn-calc/src/rpn_calc.py
+++ b/rpn-calc/src/rpn_calc.py
@@ -31,7 +31,8 @@ def parse_tokens(calculator: Calculator, tokens: List[Any]):
     FIXME: Could this be in Calculator?
     '''
     for token in tokens:
-        calculator.parse(token.rstrip())
+        if token:
+            calculator.parse(token.rstrip())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves issue #8 "Multiple spaces causes exception"

If a token is an empty string it will be ignored. Empty string tokens result from multiple spaces in a row.